### PR TITLE
Coverage fix

### DIFF
--- a/mwgs/core.py
+++ b/mwgs/core.py
@@ -67,7 +67,7 @@ class Sample(object):
             return in_handle.readline().split('\t')[-2]
 
     def gather_fraction_above_cutoff(self, cutoff):
-        cmd = ['samtools', 'depth', '-a' self.bamfile]
+        cmd = ['samtools', 'depth', '-a', self.bamfile]
         p = subprocess.Popen(cmd, stdout=subprocess.PIPE)
         proc_out, proc_error = p.communicate()
         lines = proc_out.decode('utf-8').split('\n')

--- a/mwgs/core.py
+++ b/mwgs/core.py
@@ -67,7 +67,7 @@ class Sample(object):
             return in_handle.readline().split('\t')[-2]
 
     def gather_fraction_above_cutoff(self, cutoff):
-        cmd = ['samtools', 'depth', self.bamfile]
+        cmd = ['samtools', 'depth', '-a' self.bamfile]
         p = subprocess.Popen(cmd, stdout=subprocess.PIPE)
         proc_out, proc_error = p.communicate()
         lines = proc_out.decode('utf-8').split('\n')


### PR DESCRIPTION
The -a option for samtools depth includes all bases (also not covered bases) in the bam for a more true representation of coverage of the reference genome.

Tested in D_mwgs_20180925_EOL