### PR TITLE
Added qos=high

### DIFF
--- a/mwgs/cli.py
+++ b/mwgs/cli.py
@@ -3,6 +3,7 @@
 #SBATCH -A prod001
 #SBATCH -n 16
 #SBATCH -t 40:00:00
+#SBATCH --qos=high
 #SBATCH -J mwgs-{project}
 #SBATCH -e /mnt/hds/proj/bioinfo/MICROBIAL/logs/mwgs-{project}.stderr.txt
 #SBATCH -o /mnt/hds/proj/bioinfo/MICROBIAL/logs/mwgs-{project}.stdout.txt


### PR DESCRIPTION
To avoid having to wait for MWGS the standard qos for slurm was set to high.

I have not tested this change, but what can go wrong, he? ;)